### PR TITLE
fix: Publish to npm public package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,3 +121,5 @@ jobs:
         uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_PUBLISH_TOKEN }}
+          access: public
+          strategy: all


### PR DESCRIPTION
Default is private when pkg name is scoped